### PR TITLE
Add resume after playback started from non zero starting point

### DIFF
--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="XBMC Unpause Jumpback" version="2.2.0" provider-name="Memphiz|Lucleonhart|schumi2004">
+<addon id="script.xbmc.unpausejumpback" name="XBMC Unpause Jumpback" version="2.3.0" provider-name="Memphiz|Lucleonhart|schumi2004|bossanova808">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,3 +1,6 @@
+2.3.0
+- add jumpback after playback started from non zero starting time
+
 2.2.0
 - add exclude settings
 - add jumpback/forward after fwd or rwd based on the fwd/rwd speed (can be adjusted for each speed separately for fwd and rwd).

--- a/script.xbmc.unpausejumpback/default.py
+++ b/script.xbmc.unpausejumpback/default.py
@@ -45,6 +45,7 @@ global g_jumpBackSecsAfterRwdX4
 global g_jumpBackSecsAfterRwdX8
 global g_jumpBackSecsAfterRwdX16
 global g_jumpBackSecsAfterRwdX32
+global g_jumpBackSecsAfterResume
 global g_lastPlaybackSpeed
 global g_pausedTime
 global g_waitForJumpback
@@ -115,6 +116,7 @@ def loadSettings():
   global g_jumpBackSecsAfterRwdX8
   global g_jumpBackSecsAfterRwdX16
   global g_jumpBackSecsAfterRwdX32
+  global g_jumpBackSecsAfterResume
 
   g_jumpBackSecsAfterFwdPause = int(float(__addon__.getSetting("jumpbacksecs")))
   g_jumpBackSecsAfterFwdX2 = int(float(__addon__.getSetting("jumpbacksecsfwdx2")))
@@ -127,6 +129,7 @@ def loadSettings():
   g_jumpBackSecsAfterRwdX8 = int(float(__addon__.getSetting("jumpbacksecsrwdx8")))
   g_jumpBackSecsAfterRwdX16 = int(float(__addon__.getSetting("jumpbacksecsrwdx16")))
   g_jumpBackSecsAfterRwdX32 = int(float(__addon__.getSetting("jumpbacksecsrwdx32")))
+  g_jumpBackSecsAfterResume = int(float(__addon__.getSetting("jumpbacksecsresume")))
   g_waitForJumpback = int(float(__addon__.getSetting("waitforjumpback")))
   log('Settings loaded! JumpBackSecs: %d, WaitSecs: %d' % (g_jumpBackSecsAfterFwdPause, g_waitForJumpback))
 
@@ -134,6 +137,23 @@ class MyPlayer( xbmc.Player ):
   def __init__( self, *args, **kwargs ):
     xbmc.Player.__init__( self )
     log('MyPlayer - init')
+
+  def onPlayBackStarted(self):
+    global g_jumpBackSecsAfterResume
+    currentTime = xbmc.Player().getTime()
+    log('Playback started at ' + str(currentTime))
+
+    # check for exclusion
+    _filename = self.getPlayingFile()
+    if isExcluded(_filename):
+      log("Ignored because '%s' is in exclusion settings." % _filename)
+      return
+    
+    else:
+      if currentTime > 0 and g_jumpBackSecsAfterResume > 0:
+        resumeTime = currentTime - g_jumpBackSecsAfterResume
+        log("Resuming playback from saved time: " + str(currentTime) + " with jumpback seconds: " + str(g_jumpBackSecsAfterResume) + " - resume time: " + str(resumeTime))
+        xbmc.Player().seekTime(resumeTime)
     
   def onPlayBackPaused( self ):
     global g_pausedTime

--- a/script.xbmc.unpausejumpback/resources/language/English/strings.xml
+++ b/script.xbmc.unpausejumpback/resources/language/English/strings.xml
@@ -9,15 +9,16 @@
 	<string id="32013">Jump after x8</string>
 	<string id="32014">Jump after x16</string>
 	<string id="32015">Jump after x32</string>
-        <string id="32020">Jump forward after rwd</string>
-        <string id="32021">Jump after x2</string>
-        <string id="32022">Jump after x4</string>
-        <string id="32023">Jump after x8</string>
-        <string id="32024">Jump after x16</string>
-        <string id="32025">Jump after x32</string>
+    <string id="32020">Jump forward after rwd</string>
+    <string id="32021">Jump after x2</string>
+    <string id="32022">Jump after x4</string>
+    <string id="32023">Jump after x8</string>
+    <string id="32024">Jump after x16</string>
+    <string id="32025">Jump after x32</string>
 	<string id="32030">Exclude</string>
 	<string id="32031">Exclude Live TV</string>
 	<string id="32032">Exclude HTTP sources</string>  
 	<string id="32033">Exclude path</string>
 	<string id="32034">Folder's path (and subfolders)</string>
+    <string id="32040">Jump after resume</string>
 </strings>

--- a/script.xbmc.unpausejumpback/resources/settings.xml
+++ b/script.xbmc.unpausejumpback/resources/settings.xml
@@ -18,6 +18,9 @@
     <setting id="jumpbacksecsrwdx16" type="slider" label="32024" default="16" range="0,60" />
     <setting id="jumpbacksecsrwdx32" type="slider" label="32025" default="32" range="0,60" />
   </category>
+  <category label="32040">
+    <setting id="jumpbacksecsresume" type="slider" label="32040" default="8" range="0,60" />
+  </category>
   <category label="32030">
     <setting id="ExcludeLiveTV" type="bool" label="32031" default="false"/>
     <setting id="ExcludeHTTP" type="bool" label="32032" default="false"/>    


### PR DESCRIPTION
Per this thread:
http://forum.xbmc.org/showthread.php?tid=183743&highlight=unpause+jump+back

I have added this.

I find I needed an xbmc.sleep(100) in there to make sure the currentTime call returned the currenttime - without it seems to still be at the 0 point when this is executed.  I suppose that's an xbmc.bug - this makes this work, though.

Hopefully string/logging etc is ok?
